### PR TITLE
DGR-2838 - Sync updates + CVE resolution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle": "6.5.8"
+        "guzzlehttp/guzzle": "^6.5.8"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 || ^10.0"

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     },
     "require": {
         "php": ">=5.4",
-        "guzzlehttp/guzzle": "~5.0"
+        "guzzlehttp/guzzle": "6.5.8"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.6 || ^5.0"
+        "phpunit/phpunit": "^9.0 || ^10.0"
     }
 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -85,6 +85,9 @@ class Api {
 	 */
 	public function get_credentials($group_id = null, $email = null, $page_size = null, $page = 1){
 		$client = new \GuzzleHttp\Client();
+        if ($email) {
+            $email = strtolower($email);
+        }
 
 		$params = array('headers' =>  array('Authorization' => 'Token token="'.$this->getAPIKey().'"'));
 
@@ -121,7 +124,10 @@ class Api {
 
 		$client = new \GuzzleHttp\Client();
 
-		$params = array('Authorization' => 'Token token="'.$this->getAPIKey().'"');
+		$params = array(
+			'Authorization' => 'Token token="'.$this->getAPIKey().'"',
+			'Accredible-Integration' => 'Wordpress'
+		);
 
 		$response = $client->post($this->api_endpoint.'credentials', array(
 		    'headers' => $params,
@@ -163,7 +169,10 @@ class Api {
 
         $client = new \GuzzleHttp\Client();
 
-        $params = array('Authorization' => 'Token token="'.$this->getAPIKey().'"');
+        $params = array(
+			'Authorization' => 'Token token="'.$this->getAPIKey().'"',
+			'Accredible-Integration' => 'Wordpress'
+		);
 
         $response = $client->post($this->api_endpoint.'credentials', array(
             'headers' => $params,

--- a/tests/ApiEvidenceTest.php
+++ b/tests/ApiEvidenceTest.php
@@ -16,20 +16,12 @@ use PHPUnit\Framework\TestCase;
 
 // TODO: Add mocked response tests for speed
 
-class ApiTestEvidence extends TestCase {
+class ApiEvidenceTest extends TestCase {
 
-    // backward compatibility
-    public function expectException($exception) {
-        if (!method_exists('TestCase','expectException')) {
-            $this->setExpectedException($exception);
-        } else {
-            $this->expectException($exception);
-        }
-    }
 
     public $group;
 
-	protected function setUp(){
+	protected function setUp(): void {
         $this->api = new Api("7b47e413b0216b489f0034960db4e84f", true);
 
         // Create a group
@@ -40,7 +32,7 @@ class ApiTestEvidence extends TestCase {
         $this->credential = $this->api->create_credential("John Doe", "john@example.com", $this->group->group->id);
     }
 
-    protected function tearDown(){
+    protected function tearDown(): void {
         // Remove credential
         $response = $this->api->delete_credential($this->credential->credential->id);
 
@@ -79,7 +71,7 @@ class ApiTestEvidence extends TestCase {
         $this->assertEquals("some description", $evidence_item1->evidence_item->description);
 
         //Check we can't make an invalid grade item
-        $this->expectException("\Exception");
+        $this->expectException(\Exception::class);
         $evidence_item2 = $this->api->create_evidence_item_grade("B", "some description", $this->credential->credential->id);
     }
 
@@ -89,7 +81,7 @@ class ApiTestEvidence extends TestCase {
         $this->assertEquals("Completed in 9 days", $evidence_item1->evidence_item->description);
 
         //Check we can't make an invalid duration item
-        $this->expectException("\Exception");
+        $this->expectException(\Exception::class);
         $evidence_item2 = $this->api->create_evidence_item_duration(date("Y-m-d", strtotime("2017-10-01")), date("Y-m-d", strtotime("2017-10-01")), $this->credential->credential->id);
     }
 

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -18,18 +18,10 @@ use PHPUnit\Framework\TestCase;
 
 class ApiTest extends TestCase {
 
-    // backward compatibility
-    public function expectException($exception) {
-        if (!method_exists('TestCase','expectException')) {
-            $this->setExpectedException($exception);
-        } else {
-            $this->expectException($exception);
-        }
-    }
 
     public $group;
 
-	protected function setUp(){
+	protected function setUp(): void {
         $this->api = new Api("7b47e413b0216b489f0034960db4e84f", true);
 
         // Create a group
@@ -37,7 +29,7 @@ class ApiTest extends TestCase {
         $this->group = $this->api->create_group($group_name, "Test course", "Test course description.");
     }
 
-    protected function tearDown(){
+    protected function tearDown(): void {
         // Remove group
     	$response = $this->api->delete_group($this->group->group->id);
     }
@@ -176,14 +168,14 @@ class ApiTest extends TestCase {
 
         // Can we get a group?
         $requested_designs = $this->api->get_designs(10, 1);
-        $this->assertInternalType("int", $requested_designs->designs{0}->id);
+        $this->assertIsInt($requested_designs->designs[0]->id);
     }
 
     public function testRecipientSSOLink(){
 
         //ensure the group has a design so our credential can be published
         $requested_designs = $this->api->get_designs(1, 1);
-        $this->api->update_group($this->group->group->id, null, null, null, null, $requested_designs->designs{0}->id);
+        $this->api->update_group($this->group->group->id, null, null, null, null, $requested_designs->designs[0]->id);
 
         $credential = $this->api->create_credential("John Doe", "john@example.com", $this->group->group->id);
 


### PR DESCRIPTION
**Sync updates.**
_The updates below were made in `accredible-certificates` repo_
- Add Accredible-Integration header to create credential
- Lowercase emails before comparing with credential email

**Dependencies Updated:**
- Updated `guzzlehttp/guzzle` from `~5.0` to `6.5.8`
- Updated `phpunit/phpunit` from `^4.6 || ^5.0` to `^9.0 || ^10.0` for PHP 8.x compatibility

**Security Fixes**
- CVE-2022-31091, CVE-2022-31090: Fixed in versions ≥6.5.8
- CVE-2022-31043, CVE-2022-31042: Fixed in versions ≥6.5.7

**Test Compatibility Fixes:**
- Added `void` return type declarations to `setUp()` and `tearDown()` methods in test classes
- Updated `expectException()` calls to use PHPUnit 10 syntax `(\Exception::class)`
- Replaced deprecated `assertInternalType()` with `assertIsInt()`
- Fixed deprecated curly brace array syntax `{0}` to square bracket syntax `[0]`

<img width="479" height="51" alt="image" src="https://github.com/user-attachments/assets/d4f6d8dc-b99a-400f-8fb3-a611da6ae572" />
